### PR TITLE
Removed problematic comparisons with AudioStream and SubtitleStream.

### DIFF
--- a/utils/plex.py
+++ b/utils/plex.py
@@ -69,8 +69,6 @@ class PlexUtils(object):
                 scores[index] += 3
             if reference.channels <= stream.channels:
                 scores[index] += 1
-            if reference.title <= stream.title:
-                scores[index] += 1
         return streams[scores.index(max(scores))]
 
     @staticmethod
@@ -89,10 +87,6 @@ class PlexUtils(object):
         for index, stream in enumerate(streams):
             if reference.forced == stream.forced:
                 scores[index] += 3
-            if reference.codec == stream.codec:
-                scores[index] += 1
-            if reference.title == stream.title:
-                scores[index] += 1
         return streams[scores.index(max(scores))]
 
     @staticmethod


### PR DESCRIPTION
AudioStreams were being compared by title, which is not part of that object.
SubtitleStreams were being compared by title and codec, both of which are not part of the object.

I was using the following guide as a reference [Python PlexAPI Doc](https://python-plexapi.readthedocs.io/en/latest/modules/media.html#plexapi.media.AudioStream)

I tested this locally by changing both the audio stream and subtitle and saw the intended behavior of subtitles/audio being set for the show, so I think this should resolve issue #4