### PR TITLE
Added support for Plex Token as Docker secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ python3 main.py -c ./config.yaml
 
 The application can be configured either with environment variables or with a YAML file mounted at `/config/config.yaml`. Every parameter listed in this section can be overriden with the corresponding environment variables (eg. the environment variable `PLEX_URL` will override the parameter `plex.url`, `NOTIFICATIONS_ENABLE` will override the parameter `notifications.enable` etc...).
 
+The Plex Token can also be provided as a Docker secret named `plex_token`.
+
 Here is an example of a complete configuration file:
 ```yaml
 plexautolanguages:

--- a/utils/configuration.py
+++ b/utils/configuration.py
@@ -43,6 +43,7 @@ class Configuration(object):
             logger.info(f"Parsing config file '{user_config_path}'")
             self._override_from_config_file(user_config_path)
         self._override_from_env()
+        self._override_plex_token_from_secret()
         self._validate_config()
         self._trigger_on_play = None
         self._trigger_on_activity = None
@@ -78,6 +79,15 @@ class Configuration(object):
 
     def _override_from_env(self):
         self._config = env_dict_update(self._config)
+
+    def _override_plex_token_from_secret(self):
+        plex_token_secret_path = "/run/secrets/plex_token"
+        if not os.path.exists(plex_token_secret_path):
+            return
+        logger.info("Getting PLEX_TOKEN from Docker secret")
+        with open(plex_token_secret_path, "r") as stream:
+            plex_token = stream.read()
+        self._config["plex"]["token"] = plex_token
 
     def _validate_config(self):
         if self.get("plex.url") == "":


### PR DESCRIPTION
The Plex Token can be specified with a Docker secret named `plex_token`.