### PR TITLE
Fixed secret parsing and improved Docker secret support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ python3 main.py -c ./config.yaml
 
 The application can be configured either with environment variables or with a YAML file mounted at `/config/config.yaml`. Every parameter listed in this section can be overriden with the corresponding environment variables (eg. the environment variable `PLEX_URL` will override the parameter `plex.url`, `NOTIFICATIONS_ENABLE` will override the parameter `notifications.enable` etc...).
 
-The Plex Token can also be provided as a Docker secret named `plex_token`.
+The Plex Token can also be provided as a Docker secret, the filepath of the secret must then be specified in the environment variable `PLEX_TOKEN_FILE` which defaults to `/run/secrets/plex_token`.
 
 Here is an example of a complete configuration file:
 ```yaml

--- a/utils/configuration.py
+++ b/utils/configuration.py
@@ -81,12 +81,12 @@ class Configuration(object):
         self._config = env_dict_update(self._config)
 
     def _override_plex_token_from_secret(self):
-        plex_token_secret_path = "/run/secrets/plex_token"
-        if not os.path.exists(plex_token_secret_path):
+        plex_token_file_path = os.environ.get("PLEX_TOKEN_FILE", "/run/secrets/plex_token")
+        if not os.path.exists(plex_token_file_path):
             return
         logger.info("Getting PLEX_TOKEN from Docker secret")
-        with open(plex_token_secret_path, "r") as stream:
-            plex_token = stream.read()
+        with open(plex_token_file_path, "r") as stream:
+            plex_token = stream.readline().strip()
         self._config["plex"]["token"] = plex_token
 
     def _validate_config(self):


### PR DESCRIPTION
Refactored Docker secret support as mentioned in #11:
- The Docker secret file can now be configured with the environment variable `PLEX_TOKEN_FILE`
- The parsing of the secret has been fixed