### PR TITLE
Add health-check server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.8-alpine
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
+RUN apk add --update curl && \
+    rm -rf /var/cache/apk/*
+
 COPY ./requirements.txt /app/requirements.txt
 
 RUN python3 -m pip install --no-cache-dir -r /app/requirements.txt
@@ -12,5 +15,7 @@ COPY . /app/
 WORKDIR /app
 
 VOLUME /config
+
+HEALTHCHECK CMD curl --fail http://localhost/ || exit 1
 
 ENTRYPOINT ["python3", "main.py", "-c", "/config/config.yaml"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ websocket-client>=1.3.1
 apprise>=0.9.8
 PyYAML>=6.0
 schedule>=1.1.0
-Flask>=2.1.1
+Flask>=2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ websocket-client>=1.3.1
 apprise>=0.9.8
 PyYAML>=6.0
 schedule>=1.1.0
+Flask>=2.1.1

--- a/utils/healthcheck.py
+++ b/utils/healthcheck.py
@@ -1,0 +1,41 @@
+import json
+import logging
+from flask import Flask
+from typing import Callable
+from threading import Thread
+from werkzeug.serving import make_server
+
+
+flask_logger = logging.getLogger("werkzeug")
+flask_logger.setLevel(logging.ERROR)
+
+
+class HealthcheckServer(Thread):
+
+    def __init__(self, name: str, is_ready: Callable, is_healthy: Callable):
+        super(HealthcheckServer, self).__init__()
+        self._is_healthy = is_healthy
+        self._is_ready = is_ready
+        self._app = Flask(name)
+        self._server = make_server("0.0.0.0", 80, self._app)
+        self._ctx = self._app.app_context()
+        self._ctx.push()
+
+        @self._app.route("/")
+        @self._app.route("/health")
+        def __health():
+            healthy = self._is_healthy()
+            code = 200 if healthy else 400
+            return json.dumps({"healthy": healthy}), code
+
+        @self._app.route("/ready")
+        def __ready():
+            ready = self._is_ready()
+            code = 200 if ready else 400
+            return json.dumps({"ready": ready}), code
+
+    def run(self):
+        self._server.serve_forever()
+
+    def shutdown(self):
+        self._server.shutdown()


### PR DESCRIPTION
This PR add health-check endpoints as requested by #19.

Improvements:
- Added a Flask HTTP server running on port 80 that serves two endpoints:
  - `/` or `/health`: respond code is 200 if the app is healthy, 400 otherwise
  - `/ready`:  respond code is 200 if the app is ready, 400 otherwise
- Added HEALTHCHECK command to the Dockerfile based on the `health` endpoint