### PR TITLE
Changed  health-check server port to 9880

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ WORKDIR /app
 
 VOLUME /config
 
-HEALTHCHECK CMD curl --fail http://localhost/ || exit 1
+HEALTHCHECK CMD curl --fail http://localhost:9880/ || exit 1
 
 ENTRYPOINT ["python3", "main.py", "-c", "/config/config.yaml"]

--- a/utils/healthcheck.py
+++ b/utils/healthcheck.py
@@ -17,7 +17,7 @@ class HealthcheckServer(Thread):
         self._is_healthy = is_healthy
         self._is_ready = is_ready
         self._app = Flask(name)
-        self._server = make_server("0.0.0.0", 80, self._app)
+        self._server = make_server("0.0.0.0", 9880, self._app)
         self._ctx = self._app.app_context()
         self._ctx.push()
 


### PR DESCRIPTION
The health-check server was running on port `80` and thus required elevated privileges, see #23 and #25.
The server now runs on port `9880`.