### PR TITLE
Add language update for newly added episodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ plexautolanguages:
   # Whether or not playing a file should trigger a language update, defaults to 'true'
   trigger_on_play: true
 
+  # Whether or not scanning the library for new files should trigger a language update, defaults to 'true'
+  # A newly added episode will be updated based on the most recently watched episode, or the first episode of the show if it has never been watched
+  trigger_on_scan: true
+
   # Whether or not navigating the Plex library should trigger a language update, defaults to 'false'
   # Only the Plex web client and the Plex for Windows app support this feature
   # Set this to 'true' only if you want to perform changes whenever the default track of an episode is updated, even when the episode is not played.

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -2,6 +2,7 @@ plexautolanguages:
   update_level: "show"
   update_strategy: "next"
   trigger_on_play: true
+  trigger_on_scan: true
   trigger_on_activity: false
 
   plex:


### PR DESCRIPTION
Automatically update the language of newly added episode.
This feature can be turned off with the parameter `trigger_on_scan`.

Newly added episodes are processed either with a `timeline` or a `status` message.