### PR TITLE
Add event filter for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,13 @@ plexautolanguages:
     # A notification is sent whenever a language change is performed
     enable: true
     # An array of Apprise configurations, see Apprise docs for more information: https://github.com/caronc/apprise
+    # The array 'users' can be specified in order to link notification URLs with specific users
+    #   Defaults to all users if not present
+    # The array 'events' can be specified in order to get notifications only for specific events
+    #   Valid event values: "play_or_activity" "new_episode" "updated_episode" "scheduler"
+    #   Defaults to all events if not present
     apprise_configs:
-      # This URL will be notified of all changes
+      # This URL will be notified of all changes during all events
       - "discord://webhook_id/webhook_token"
       # These URLs will only be notified of language change for users "MyUser1" and "MyUser2"
       - urls:
@@ -146,9 +151,18 @@ plexautolanguages:
         users:
           - "MyUser1"
           - "MyUser2"
-      # This URL will only be notified of language change for user "MyUser3"
-      - urls: "tgram://bottoken/ChatID"
-        users: "MyUser3"
+      # This URL will only be notified of language change for user "MyUser3" during play or activity events
+      - urls:
+          - "tgram://bottoken/ChatID"
+        users:
+          - "MyUser3"
+        events:
+          - "play_or_activity"
+      # This URL will be notified of language change during scheduler tasks only
+      - urls:
+          - "gotify://hostname/token"
+        events:
+          - "scheduler"
       - "..."
 
   # Whether or not to enable the debug mode, defaults to 'false'

--- a/plex_auto_languages/alerts/activity.py
+++ b/plex_auto_languages/alerts/activity.py
@@ -5,6 +5,7 @@ from plexapi.video import Episode
 
 from plex_auto_languages.alerts.base import PlexAlert
 from plex_auto_languages.utils.logger import get_logger
+from plex_auto_languages.constants import EventType
 
 if TYPE_CHECKING:
     from plex_auto_languages.plex_server import PlexServer
@@ -70,4 +71,4 @@ class PlexActivity(PlexAlert):
         if user is None:
             return
         logger.debug(f"[Activity] User: {user.name} | Episode: {item}")
-        plex.change_default_tracks_if_needed(user.name, item)
+        plex.change_tracks(user.name, item, EventType.PLAY_OR_ACTIVITY)

--- a/plex_auto_languages/alerts/playing.py
+++ b/plex_auto_languages/alerts/playing.py
@@ -4,6 +4,7 @@ from plexapi.video import Episode
 
 from plex_auto_languages.alerts.base import PlexAlert
 from plex_auto_languages.utils.logger import get_logger
+from plex_auto_languages.constants import EventType
 
 if TYPE_CHECKING:
     from plex_auto_languages.plex_server import PlexServer
@@ -73,4 +74,4 @@ class PlexPlaying(PlexAlert):
         plex.cache.default_streams.setdefault(item.key, pair_id)
 
         # Change tracks if needed
-        plex.change_default_tracks_if_needed(username, item)
+        plex.change_tracks(username, item, EventType.PLAY_OR_ACTIVITY)

--- a/plex_auto_languages/alerts/status.py
+++ b/plex_auto_languages/alerts/status.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 from plex_auto_languages.alerts.base import PlexAlert
 from plex_auto_languages.utils.logger import get_logger
+from plex_auto_languages.constants import EventType
 
 if TYPE_CHECKING:
     from plex_auto_languages.plex_server import PlexServer
@@ -37,7 +38,7 @@ class PlexStatus(PlexAlert):
 
                 # Change tracks for all users
                 logger.info(f"[Status] Processing newly added episode {plex.get_episode_short_name(item)}")
-                plex.process_new_or_updated_episode(item.key)
+                plex.process_new_or_updated_episode(item.key, EventType.NEW_EPISODE)
 
         # Process updated episodes
         if len(updated) > 0:
@@ -45,4 +46,4 @@ class PlexStatus(PlexAlert):
             for item in updated:
                 # Change tracks for all users
                 logger.info(f"[Status] Processing updated episode {plex.get_episode_short_name(item)}")
-                plex.process_new_or_updated_episode(item.key, new=False)
+                plex.process_new_or_updated_episode(item.key, EventType.UPDATED_EPISODE)

--- a/plex_auto_languages/alerts/timeline.py
+++ b/plex_auto_languages/alerts/timeline.py
@@ -5,6 +5,7 @@ from plexapi.video import Episode
 
 from plex_auto_languages.alerts.base import PlexAlert
 from plex_auto_languages.utils.logger import get_logger
+from plex_auto_languages.constants import EventType
 
 if TYPE_CHECKING:
     from plex_auto_languages.plex_server import PlexServer
@@ -60,4 +61,4 @@ class PlexTimeline(PlexAlert):
 
         # Change tracks for all users
         logger.info(f"[Timeline] Processing newly added episode {plex.get_episode_short_name(item)}")
-        plex.process_new_or_updated_episode(self.item_id)
+        plex.process_new_or_updated_episode(self.item_id, EventType.NEW_EPISODE)

--- a/plex_auto_languages/constants.py
+++ b/plex_auto_languages/constants.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class EventType(Enum):
+
+    PLAY_OR_ACTIVITY = 0
+    NEW_EPISODE = 1
+    UPDATED_EPISODE = 2
+    SCHEDULER = 3

--- a/plex_auto_languages/utils/notifier.py
+++ b/plex_auto_languages/utils/notifier.py
@@ -1,39 +1,74 @@
 from typing import List, Union
 from apprise import Apprise
 
+from plex_auto_languages.constants import EventType
+
 
 class Notifier():
 
     def __init__(self, configs: List[Union[str, dict]]):
-        self._global_apprise = Apprise()
+        self._global_apprise = ConditionalApprise()
         self._user_apprise = {}
 
         for config in configs:
             if isinstance(config, str):
-                self._add_urls([config], None)
+                self._add_urls([config])
             if isinstance(config, dict) and "urls" in config:
-                targets = config.get("urls")
-                targets = [targets] if isinstance(targets, str) else targets
+                urls = config.get("urls")
+                urls = [urls] if isinstance(urls, str) else urls
                 usernames = config.get("users", None)
-                usernames = [usernames] if isinstance(usernames, str) else usernames
-                self._add_urls(targets, usernames)
+                if usernames is None:
+                    usernames = []
+                elif isinstance(usernames, str):
+                    usernames = [usernames]
+                event_types = config.get("events", None)
+                if event_types is None:
+                    event_types = []
+                elif isinstance(event_types, str):
+                    event_types = [EventType[event_types.upper()]]
+                elif isinstance(event_types, list):
+                    event_types = [EventType[et.upper()] for et in event_types]
+                self._add_urls(urls, usernames, event_types)
 
-    def _add_urls(self, urls: List[str], usernames: List[str] = None):
+    def _add_urls(self, urls: List[str], usernames: List[str] = None, event_types: List[EventType] = None):
         if usernames is None or len(usernames) == 0:
             for url in urls:
                 self._global_apprise.add(url)
+            if event_types is not None:
+                self._global_apprise.add_event_types(event_types)
             return
         for username in usernames:
-            user_apprise = self._user_apprise.setdefault(username, Apprise())
+            user_apprise = self._user_apprise.setdefault(username, ConditionalApprise())
             for url in urls:
                 user_apprise.add(url)
+            if event_types is not None:
+                user_apprise.add_event_types(event_types)
 
-    def notify(self, title: str, message: str):
-        self._global_apprise.notify(title=title, body=message)
+    def notify(self, title: str, message: str, event_type: EventType):
+        self._global_apprise.notifiy_if_needed(title, message, event_type)
 
-    def notify_user(self, title: str, message: str, username: str):
-        self._global_apprise.notify(title=title, body=message)
+    def notify_user(self, title: str, message: str, username: str, event_type: EventType):
+        self._global_apprise.notifiy_if_needed(title, message, event_type)
         if username is None or username not in self._user_apprise:
             return
-        for user_apprise in self._user_apprise[username]:
-            user_apprise.notify(title=title, body=message)
+        user_apprise = self._user_apprise[username]
+        user_apprise.notifiy_if_needed(title, message, event_type)
+
+
+class ConditionalApprise(Apprise):
+
+    def __init__(self):
+        super().__init__()
+        self._event_types = set()
+
+    def add_event_type(self, event_type: EventType):
+        self._event_types.add(event_type)
+
+    def add_event_types(self, event_types: List[EventType]):
+        for event_type in event_types:
+            self.add_event_type(event_type)
+
+    def notifiy_if_needed(self, title: str, body: str, event_type: EventType):
+        if len(self._event_types) != 0 and event_type not in self._event_types:
+            return
+        self.notify(title=title, body=body)


### PR DESCRIPTION
This PR implements enhancements requested in #36.

Notification configurations can now have an additional `events` array that allows for getting notifications only for a set of events.

Example configurations:
```yaml
plexautolanguages:

  [...]

  notifications:
    enable: true
    apprise_configs:
      - urls:
          - "tgram://bottoken/ChatID"
        users:
          - "MyUser3"
        events:
          - "play_or_activity"
      - urls:
          - "gotify://hostname/token"
          - "tgram://bottoken/ChatID"
        events:
          - "scheduler"
          - "new_episode"
```


Valid events are:
- `play_or_activity`
- `new_episode`
- `updated_episode`
- `scheduler`