### PR TITLE
Add file cache for Plex library

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ services:
       - PLEX_URL=http://plex:32400
       - PLEX_TOKEN=MY_PLEX_TOKEN
       - TZ=Europe/Paris
+    volumes:
+      - ./config:/config
 ```
 
 ### Docker compose advanced configuration
 
-Here is an example of a docker-compose configuration that uses a YAML configuration file, see [Configuration](#configuration) for more information:
+Here is an example of a docker-compose configuration that uses a YAML configuration file `config.yaml` inside a `config` directory, see [Configuration](#configuration) for more information:
 ```yaml
 version: "3"
 services:
@@ -54,7 +56,8 @@ services:
     environment:
       - TZ=Europe/Paris
     volumes:
-      - ./config.yaml:/config/config.yaml
+      # make sure you have a file named 'config.yaml' in the 'config' dir
+      - ./config:/config
     restart: unless-stopped
 ```
 
@@ -116,6 +119,11 @@ plexautolanguages:
   # Set this to 'true' only if you want to perform changes whenever the default track of an episode is updated, even when the episode is not played.
   # Setting this parameter to 'true' can result in higher resource usage.
   trigger_on_activity: false
+
+  # Whether or not to refresh the cached library whenever the Plex server scans its own library, defaults to 'true'
+  # Disabling this parameter will prevent PlexAutoLanguages from detecting updated files for an already existing episode
+  # It is recommended to disable this parameter if you have a large TV Show library (10k+ episodes)
+  refresh_library_on_scan: true
 
   # Plex configuration
   plex:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -4,6 +4,7 @@ plexautolanguages:
   trigger_on_play: true
   trigger_on_scan: true
   trigger_on_activity: false
+  refresh_library_on_scan: true
 
   plex:
     url: ""

--- a/main.py
+++ b/main.py
@@ -15,7 +15,6 @@ class PlexAutoLanguages():
     def __init__(self, user_config_path: str):
         self.alive = False
         self.plex_alert_listener = None
-        self.set_signal_handlers()
 
         # Health-check server
         self.healthcheck_server = HealthcheckServer("Plex-Auto-Languages", self.is_ready, self.is_healthy)
@@ -36,6 +35,8 @@ class PlexAutoLanguages():
         self.scheduler = None
         if self.config.get("scheduler.enable"):
             self.scheduler = Scheduler(self.config.get("scheduler.schedule_time"), self.scheduler_callback)
+
+        self.set_signal_handlers()
 
     def is_ready(self):
         return self.alive
@@ -60,6 +61,7 @@ class PlexAutoLanguages():
         self.alive = True
         while self.is_healthy():
             sleep(1)
+        self.plex.save_cache()
         if self.scheduler:
             logger.info("Stopping scheduler")
             self.scheduler.stop_event.set()

--- a/plex_auto_languages/alerts/status.py
+++ b/plex_auto_languages/alerts/status.py
@@ -23,18 +23,21 @@ class PlexStatus(PlexAlert):
     def process(self, plex: PlexServer):
         if self.title != "Library scan complete":
             return
-        logger.info("[Status] Library scan complete")
+        logger.info("[Status] The Plex server scanned the library")
 
-        added, updated = plex.cache.refresh_library_cache()
+        if plex.config.get("refresh_library_on_scan"):
+            added, updated = plex.cache.refresh_library_cache()
+        else:
+            added = plex.get_recently_added_episodes(minutes=5)
+            updated = []
 
         # Process recently added episodes
         if len(added) > 0:
             logger.debug(f"[Status] Found {len(added)} newly added episode(s)")
             for item in added:
                 # Check if the item has already been processed
-                if item.key in plex.cache.newly_added and plex.cache.newly_added[item.key] == item.addedAt:
+                if not plex.cache.should_process_recently_added(item.key, item.addedAt):
                     continue
-                plex.cache.newly_added[item.key] = item.addedAt
 
                 # Change tracks for all users
                 logger.info(f"[Status] Processing newly added episode {plex.get_episode_short_name(item)}")
@@ -44,6 +47,10 @@ class PlexStatus(PlexAlert):
         if len(updated) > 0:
             logger.debug(f"[Status] Found {len(updated)} updated episode(s)")
             for item in updated:
+                # Check if the item has already been processed
+                if not plex.cache.should_process_recently_updated(item.key):
+                    continue
+
                 # Change tracks for all users
                 logger.info(f"[Status] Processing updated episode {plex.get_episode_short_name(item)}")
                 plex.process_new_or_updated_episode(item.key, EventType.UPDATED_EPISODE)

--- a/plex_auto_languages/alerts/status.py
+++ b/plex_auto_languages/alerts/status.py
@@ -23,7 +23,7 @@ class PlexStatus(PlexAlert):
     def process(self, plex: PlexServer):
         if self.title != "Library scan complete":
             return
-        logger.info("[Status] The Plex server scanned the library")
+        logger.debug("[Status] The Plex server scanned the library")
 
         if plex.config.get("refresh_library_on_scan"):
             added, updated = plex.cache.refresh_library_cache()

--- a/plex_auto_languages/alerts/status.py
+++ b/plex_auto_languages/alerts/status.py
@@ -41,7 +41,7 @@ class PlexStatus(PlexAlert):
 
                 # Change tracks for all users
                 logger.info(f"[Status] Processing newly added episode {plex.get_episode_short_name(item)}")
-                plex.process_new_or_updated_episode(item.key, EventType.NEW_EPISODE)
+                plex.process_new_or_updated_episode(item.key, EventType.NEW_EPISODE, True)
 
         # Process updated episodes
         if len(updated) > 0:
@@ -53,4 +53,4 @@ class PlexStatus(PlexAlert):
 
                 # Change tracks for all users
                 logger.info(f"[Status] Processing updated episode {plex.get_episode_short_name(item)}")
-                plex.process_new_or_updated_episode(item.key, EventType.UPDATED_EPISODE)
+                plex.process_new_or_updated_episode(item.key, EventType.UPDATED_EPISODE, False)

--- a/plex_auto_languages/alerts/timeline.py
+++ b/plex_auto_languages/alerts/timeline.py
@@ -54,10 +54,12 @@ class PlexTimeline(PlexAlert):
             return
 
         # Check if the item has been added recently
-        if item.addedAt < datetime.now() - timedelta(minutes=5) or \
-                (item.key in plex.cache.newly_added and plex.cache.newly_added[item.key] == item.addedAt):
+        if item.addedAt < datetime.now() - timedelta(minutes=5):
             return
-        plex.cache.newly_added[item.key] = item.addedAt
+
+        # Check if the item has already been processed
+        if not plex.cache.should_process_recently_added(item.key, item.addedAt):
+            return
 
         # Change tracks for all users
         logger.info(f"[Timeline] Processing newly added episode {plex.get_episode_short_name(item)}")

--- a/plex_auto_languages/alerts/timeline.py
+++ b/plex_auto_languages/alerts/timeline.py
@@ -63,4 +63,4 @@ class PlexTimeline(PlexAlert):
 
         # Change tracks for all users
         logger.info(f"[Timeline] Processing newly added episode {plex.get_episode_short_name(item)}")
-        plex.process_new_or_updated_episode(self.item_id, EventType.NEW_EPISODE)
+        plex.process_new_or_updated_episode(self.item_id, EventType.NEW_EPISODE, True)

--- a/plex_auto_languages/plex_server.py
+++ b/plex_auto_languages/plex_server.py
@@ -140,8 +140,8 @@ class PlexServer(UnprivilegedPlexServer):
             return None
         return matching_users[0]
 
-    def process_new_or_updated_episode(self, item_id: Union[int, str], event_type: EventType):
-        track_changes = NewOrUpdatedTrackChanges(event_type)
+    def process_new_or_updated_episode(self, item_id: Union[int, str], event_type: EventType, new: bool):
+        track_changes = NewOrUpdatedTrackChanges(event_type, new)
         for user_id in self.get_all_user_ids():
             # Switch to the user's Plex instance
             user_plex = self.get_plex_instance_of_user(user_id)
@@ -210,9 +210,9 @@ class PlexServer(UnprivilegedPlexServer):
             if not self.cache.should_process_recently_added(item.key, item.addedAt):
                 continue
             logger.info(f"[Scheduler] Processing newly added episode {self.get_episode_short_name(item)}")
-            self.process_new_or_updated_episode(item.key, EventType.SCHEDULER)
+            self.process_new_or_updated_episode(item.key, EventType.SCHEDULER, True)
         for item in updated:
             if not self.cache.should_process_recently_updated(item.key):
                 continue
             logger.info(f"[Scheduler] Processing updated episode {self.get_episode_short_name(item)}")
-            self.process_new_or_updated_episode(item.key, EventType.SCHEDULER)
+            self.process_new_or_updated_episode(item.key, EventType.SCHEDULER, False)

--- a/plex_auto_languages/plex_server.py
+++ b/plex_auto_languages/plex_server.py
@@ -37,12 +37,12 @@ class UnprivilegedPlexServer():
             return None
 
     def episodes(self):
-        return self._plex.library.all(libtype="episode")
+        return self._plex.library.all(libtype="episode", container_size=1024)
 
     def get_recently_added_episodes(self, minutes: int):
         episodes = []
         for section in self.get_show_sections():
-            recent = section.searchEpisodes(filters={"addedAt>>": f"{minutes}m"})
+            recent = section.searchEpisodes(sort="addedAt:desc", filters={"addedAt>>": f"{minutes}m"})
             episodes.extend(recent)
         return episodes
 
@@ -98,6 +98,9 @@ class PlexServer(UnprivilegedPlexServer):
             if account.name == plex_username:
                 return account.id, account.name
         return None, None
+
+    def save_cache(self):
+        self.cache.save()
 
     def start_alert_listener(self):
         trigger_on_play = self.config.get("trigger_on_play")
@@ -200,3 +203,16 @@ class PlexServer(UnprivilegedPlexServer):
                 continue
             episode.reload()
             self.change_tracks(user.name, episode, EventType.SCHEDULER)
+
+        # Scan library
+        added, updated = self.cache.refresh_library_cache()
+        for item in added:
+            if not self.cache.should_process_recently_added(item.key, item.addedAt):
+                continue
+            logger.info(f"[Scheduler] Processing newly added episode {self.get_episode_short_name(item)}")
+            self.process_new_or_updated_episode(item.key, EventType.SCHEDULER)
+        for item in updated:
+            if not self.cache.should_process_recently_updated(item.key):
+                continue
+            logger.info(f"[Scheduler] Processing updated episode {self.get_episode_short_name(item)}")
+            self.process_new_or_updated_episode(item.key, EventType.SCHEDULER)

--- a/plex_auto_languages/plex_server_cache.py
+++ b/plex_auto_languages/plex_server_cache.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
+import os
+import json
+from datetime import datetime
 from typing import TYPE_CHECKING
+from dateutil.parser import isoparse
 
 from plex_auto_languages.utils.logger import get_logger
 
@@ -14,18 +18,34 @@ class PlexServerCache():
 
     def __init__(self, plex: PlexServer):
         self._plex = plex
+        self._cache_file_path = self._get_cache_file_path()
+        self._last_refresh = datetime.fromtimestamp(0)
         # Alerts cache
         self.session_states = {}     # session_key: session_state
         self.default_streams = {}    # item_key: (audio_stream_id, substitle_stream_id)
         self.user_clients = {}       # client_identifier: user_id
         self.newly_added = {}        # episode_id: added_at
+        self.newly_updated = {}      # episode_id: updated_at
         self.recent_activities = {}  # (user_id, item_id): timestamp
         # Library cache
         self.episode_parts = {}
         # Initialization
-        logger.info("Scanning all episodes from the library, this action can take a few seconds")
-        self.refresh_library_cache()
-        logger.info(f"Scanned {len(self.episode_parts)} episodes from the library")
+        if not self._load():
+            logger.info("Scanning all episodes from the library, this action can take a few seconds")
+            self.refresh_library_cache()
+            logger.info(f"Scanned {len(self.episode_parts)} episodes from the library")
+
+    def should_process_recently_added(self, episode_id: str, added_at: datetime):
+        if episode_id in self.newly_added and self.newly_added[episode_id] == added_at:
+            return False
+        self.newly_added[episode_id] = added_at
+        return True
+
+    def should_process_recently_updated(self, episode_id: str):
+        if episode_id in self.newly_updated and self.newly_updated[episode_id] >= self._last_refresh:
+            return False
+        self.newly_updated[episode_id] = datetime.now()
+        return True
 
     def refresh_library_cache(self):
         logger.debug("[Cache] Refreshing library cache")
@@ -41,4 +61,37 @@ class PlexServerCache():
             elif episode.key not in self.episode_parts:
                 added.append(episode)
         self.episode_parts = new_episode_parts
+        logger.debug("[Cache] Done refreshing library cache")
+        self._last_refresh = datetime.now()
+        self.save()
         return added, updated
+
+    def _get_cache_file_path(self):
+        data_dir = self._plex.config.get("data_dir")
+        cache_dir = os.path.join(data_dir, "cache")
+        if not os.path.exists(cache_dir):
+            os.makedirs(cache_dir)
+        return os.path.join(cache_dir, self._plex.unique_id)
+
+    def _load(self):
+        if not os.path.exists(self._cache_file_path):
+            return False
+        logger.debug("[Cache] Loading server cache from file")
+        with open(self._cache_file_path, "r", encoding="utf-8") as stream:
+            cache = json.load(stream)
+        self.newly_updated = cache.get("newly_updated", self.newly_updated)
+        self.newly_added = cache.get("newly_added", self.newly_added)
+        self.episode_parts = cache.get("episode_parts", )
+        self._last_refresh = isoparse(cache.get("last_refresh", self._last_refresh))
+        return True
+
+    def save(self):
+        logger.debug("[Cache] Saving server cache to file")
+        cache = {
+            "newly_updated": self.newly_updated,
+            "newly_added": self.newly_added,
+            "episode_parts": self.episode_parts,
+            "last_refresh": self._last_refresh.isoformat()
+        }
+        with open(self._cache_file_path, "w", encoding="utf-8") as stream:
+            json.dump(cache, stream)

--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -189,9 +189,10 @@ class TrackChanges():
 
 class NewOrUpdatedTrackChanges():
 
-    def __init__(self, event_type: EventType):
+    def __init__(self, event_type: EventType, new: bool):
         self._episode = None
         self._event_type = event_type
+        self._new = new
         self._track_changes = []
         self._description = ""
         self._title = ""
@@ -236,7 +237,7 @@ class NewOrUpdatedTrackChanges():
             self._description = ""
             self._episode = None
             return
-        event_str = "New" if self._event_type == EventType.NEW_EPISODE else "Updated"
+        event_str = "New" if self._new else "Updated"
         self._title = f"{event_str}: {self.episode_name}"
         self._description = (
             f"Episode: {self.episode_name}\n"

--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -93,7 +93,8 @@ class TrackChanges():
 
     def apply(self):
         if not self.has_changes:
-            logger.debug(f"[Language Update] No changes to perform for episode {self._reference} and user '{self.username}'")
+            logger.debug(f"[Language Update] No changes to perform for show "
+                         f"{self._reference.show()} and user '{self.username}'")
             return
         logger.debug(f"[Language Update] Performing {len(self._changes)} change(s) for show {self._reference.show()}")
         for episode, part, stream_type, new_stream in self._changes:

--- a/plex_auto_languages/utils/json.py
+++ b/plex_auto_languages/utils/json.py
@@ -1,0 +1,10 @@
+import json
+from datetime import datetime, date, time
+
+
+class DateTimeEncoder(json.JSONEncoder):
+
+    def default(self, obj):
+        if isinstance(obj, (datetime, date, time)):
+            return obj.isoformat()
+        return super(DateTimeEncoder, self).default(obj)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ apprise>=0.9.8
 PyYAML>=6.0
 schedule>=1.1.0
 Flask>=2.0.3
+python-dateutil>=2.8.2


### PR DESCRIPTION
As mentioned in #35, the current approach is not suited for huge libraries as the scan of the Plex library happens too often and can take too much time.

This PR adds:
- A cache file for the `PlexServerCache` class
- A parameter `refresh_library_on_scan` that prevents PAL from refreshing the library on every Plex scan if set to `false`. The drawback of disabling this is that the episode with updated files will no longer be picked up outside of the scheduler task
- A complete scan of the library by the scheduler