### PR TITLE
add tini to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-alpine
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-RUN apk add --update curl && \
+RUN apk add --update curl tini && \
     rm -rf /var/cache/apk/*
 
 COPY ./requirements.txt /app/requirements.txt
@@ -18,4 +18,4 @@ VOLUME /config
 
 HEALTHCHECK CMD curl --silent --fail http://localhost:9880/ || exit 1
 
-ENTRYPOINT ["python3", "main.py", "-c", "/config/config.yaml"]
+ENTRYPOINT ["/sbin/tini", "-s", "python3", "main.py", "-c", "/config/config.yaml"]


### PR DESCRIPTION
Would make the container shut down properly rather than having to wait for the delay set before it is killed.

https://github.com/krallin/tini