### PR TITLE
Subs no longer switch to "Off" if a matching subtitle isn't found.

### DIFF
--- a/plex_auto_languages/alerts/playing.py
+++ b/plex_auto_languages/alerts/playing.py
@@ -63,6 +63,9 @@ class PlexPlaying(PlexAlert):
             logger.debug(f"[Play Session] End of session {self.session_key} for user {user_id}")
             del plex.cache.session_states[self.session_key]
             del plex.cache.user_clients[self.client_identifier]
+        # my modification here: only updates on stopped, not playing
+        else: 
+            return
 
         # Skip if selected streams are unchanged
         item.reload()

--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -83,9 +83,15 @@ class TrackChanges():
                     self._changes.append((episode, part, AudioStream.STREAMTYPE, matching_audio_stream))
                 # Subtitle stream
                 matching_subtitle_stream = self._match_subtitle_stream(part.subtitleStreams())
-                if current_subtitle_stream is not None and matching_subtitle_stream is None:
-                    self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
-                if matching_subtitle_stream is not None and \
+                # removed code
+                # if current_subtitle_stream is not None and matching_subtitle_stream is None:
+                #     self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
+
+                # my modification here: if selected subs is "None" AND there are other options for subtitles, then we sync "None"
+                if self._subtitle_stream is None:
+                    if len(self._reference.subtitleStreams()) > 0:
+                        self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
+                elif matching_subtitle_stream is not None and \
                         (current_subtitle_stream is None or matching_subtitle_stream.id != current_subtitle_stream.id):
                     self._changes.append((episode, part, SubtitleStream.STREAMTYPE, matching_subtitle_stream))
         self._update_description(episodes)


### PR DESCRIPTION
Selecting "None/Off" now syncs (only if there are other options.) trigger_on_play only triggers on "stopped" now to prevent a couple bugs.