### PR TITLE
Reduce `container_size` to max allowed by plex.

### DIFF
--- a/plex_auto_languages/plex_server.py
+++ b/plex_auto_languages/plex_server.py
@@ -59,7 +59,7 @@ class UnprivilegedPlexServer():
             return None
 
     def episodes(self):
-        return self._plex.library.all(libtype="episode", container_size=1024)
+        return self._plex.library.all(libtype="episode", container_size=1000)
 
     def get_recently_added_episodes(self, minutes: int):
         episodes = []


### PR DESCRIPTION
Plex claims that `container_size` >1000 will cause 400 response codes in the future.