### PR TITLE
feat: Push container image to GHCR

### DIFF
--- a/.github/workflows/dockerhub_build_push.yml
+++ b/.github/workflows/dockerhub_build_push.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/dockerhub_build_push.yml
+++ b/.github/workflows/dockerhub_build_push.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           images: |
             docker.io/remirigal/plex-auto-languages
-            ghcr.io/${{ github.repository }}
+            ghcr.io/remirigal/plex-auto-languages
           tags: |
             type=ref,event=branch
             type=ref,event=tag

--- a/.github/workflows/dockerhub_build_push.yml
+++ b/.github/workflows/dockerhub_build_push.yml
@@ -9,29 +9,37 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
-          images: remirigal/plex-auto-languages
+          images: |
+            docker.io/remirigal/plex-auto-languages
+            ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true


### PR DESCRIPTION
Hi @RemiRigal👋🏼 Awesome project here...

Dockerhub has aggressive pull rate limits, it would be awesome if you could push the image to Github Container Registry (GHCR) too.

Dockerhub was one of the best years ago... GHCR is completely free for open source projects. It's also nice in that it integrates into your repo under the packages section. Take a look at my project [here](https://github.com/onedr0p/exportarr) and look at the packages on the right side.

Thanks!

Edit: This also bumps deps in the workflow