### PR TITLE
Fix NotImplementedError in start_deep_analysis by using source() for episode history objects

### DIFF
--- a/plex_auto_languages/plex_server.py
+++ b/plex_auto_languages/plex_server.py
@@ -280,8 +280,10 @@ class PlexServer(UnprivilegedPlexServer):
             user = self.get_user_by_id(episode.accountID)
             if user is None:
                 continue
-            episode.reload()
-            self.change_tracks(user.name, episode, EventType.SCHEDULER)
+            episode = episode.source()
+            if episode is not None:
+                episode.reload()
+                self.change_tracks(user.name, episode, EventType.SCHEDULER)
 
         # Scan library
         added, updated = self.cache.refresh_library_cache()


### PR DESCRIPTION
Resolved an issue in start_deep_analysis where calling reload() on a history object caused a NotImplementedError. 
Updated the method to use the source() method to retrieve the actual episode before calling reload(), ensuring compatibility with change_tracks and preventing the exception from occurring. Also added a check for None to handle cases where episode.source() returns None, indicating the episode has been deleted.

Resolves #99
