### PR TITLE
Fixes crashes when streaming live TV

### DIFF
--- a/plex_auto_languages/alerts/playing.py
+++ b/plex_auto_languages/alerts/playing.py
@@ -46,6 +46,10 @@ class PlexPlaying(PlexAlert):
         if user_plex is None:
             return
 
+        # Check if key is streaming live TV
+        if self.item_key is None or self.item_key.startswith("/livetv"):
+            return
+
         # Skip if not an Episode
         item = user_plex.fetch_item(self.item_key)
         if item is None or not isinstance(item, Episode):


### PR DESCRIPTION
Fixes: #102, #116

Ignore playing status if we are streaming live TV.
This fixes PAL crashes when Plex is streaming live TV.

I created a new docker image for this before PR is accepted:

`racle90/plex-auto-languages:latest`

https://hub.docker.com/r/racle90/plex-auto-languages 