### PR TITLE
Update deprecated python-plexapi methods

### DIFF
--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -101,11 +101,11 @@ class TrackChanges():
             stream_type_name = "audio" if stream_type == AudioStream.STREAMTYPE else "subtitle"
             logger.debug(f"[Language Update] Updating {stream_type_name} stream of episode {episode} to {new_stream}")
             if stream_type == AudioStream.STREAMTYPE:
-                part.setDefaultAudioStream(new_stream)
+                part.setSelectedAudioStream(new_stream)
             elif stream_type == SubtitleStream.STREAMTYPE and new_stream is None:
-                part.resetDefaultSubtitleStream()
+                part.resetSelectedSubtitleStream()
             elif stream_type == SubtitleStream.STREAMTYPE:
-                part.setDefaultSubtitleStream(new_stream)
+                part.setSelectedSubtitleStream(new_stream)
 
     def _is_episode_after(self, episode: Episode):
         return self._reference.seasonNumber < episode.seasonNumber or \


### PR DESCRIPTION
Since few weeks, deprecated methods have been removed from python-plexapi mediay.py (see https://github.com/pushingkarmaorg/python-plexapi/blob/master/plexapi/media.py).

Which cause the audio and subtitle update to fail. This error can be observed in python3 output:
```
2026-02-21 10:38:20,199 [ERROR] Unable to process playing
Traceback (most recent call last):
  File "/home/user/Plex-Auto-Languages/plex_auto_languages/plex_alert_handler.py", line 66, in _process_alerts
    alert.process(self._plex)
    ~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/user/Plex-Auto-Languages/plex_auto_languages/alerts/playing.py", line 84, in process
    plex.change_tracks(username, item, EventType.PLAY_OR_ACTIVITY)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Plex-Auto-Languages/plex_auto_languages/plex_server.py", line 259, in change_tracks
    track_changes.apply()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/home/user/Plex-Auto-Languages/plex_auto_languages/track_changes.py", line 104, in apply
    part.setDefaultAudioStream(new_stream)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'MediaPart' object has no attribute 'setDefaultAudioStream'. Did you mean: 'setSelectedAudioStream'?
```

I updated the 3 deprecated methods in order to fix the issue:
- `setDefaultAudioStream` -> `setSelectedAudioStream`
- `resetDefaultSubtitleStream` -> `resetSelectedSubtitleStream`
- `setDefaultSubtitleStream` -> `setSelectedSubtitleStream`

With these few changes, it works like a charm.